### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project includes an example iPad and iPhone app that makes use of `SparkAPI
 ## Requirements
 
 * iOS 5 or later
-* XCode IDE
+* Xcode IDE
 * Running on an iOS device requires an active Apple Developer account
 
 ## Configuration
@@ -218,6 +218,6 @@ In `LoginViewController`, the `processAuthentication` method should also be modi
 
 Tested OSs: iOS 6, iOS 5
 
-Tested XCode versions: 4.5
+Tested Xcode versions: 4.5
 
 Tested Devices: iPad 3, iPad 2, iPad mini, iPad 1, iPhone 5, iPhone 4


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
